### PR TITLE
Add a tooltip property to labels

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -238,11 +238,12 @@ All props are optional. The following props are supported:
   {
     type?: <string> | null,
     label?: <string> | null
+    tooltip?: <string> | null
   }
   ```
 
-  The string specified in `label` is shown as tooltip. Shudan provides styles
-  for the following types:
+  The string specified in `label` is shown as tooltip by default if `tooltip`
+  is not given. Shudan provides styles for the following types:
 
   - `'circle'`
   - `'cross'`

--- a/src/Goban.d.ts
+++ b/src/Goban.d.ts
@@ -15,6 +15,7 @@ export interface Marker {
     | "label"
     | null;
   label?: string | null;
+  tooltip?: string | null;
 }
 
 export interface GhostStone {

--- a/src/Vertex.js
+++ b/src/Vertex.js
@@ -65,7 +65,7 @@ export default function Vertex(props) {
         "data-x": position[0],
         "data-y": position[1],
 
-        title: marker?.label,
+        title: marker?.tooltip ?? marker?.label,
         style: {
           position: "relative",
         },


### PR DESCRIPTION
It overrides the default tooltip of using the label itself. It's optional so this is a non-breaking change. 