### PR TITLE
Support boards with grid images, more stone variations

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -108,6 +108,44 @@ certain classes to customize the appearance:
 }
 ```
 
+The goban also has a size-specific class such as `shudan-board-9x9`,
+`shudan-board-13x13`, or `shudan-board-19x19`. Its `data-shudan-board-width` and
+`data-shudan-board-height` attributes expose the same dimensions separately.
+Themes can use these hooks to replace the vector grid with a board image that
+has its grid baked in:
+
+```css
+.shudan-board-9x9 .shudan-content {
+  background: url("./board-9x9.png") center / 100% 100% no-repeat;
+}
+
+.shudan-board-9x9 .shudan-grid {
+  display: none;
+}
+
+.shudan-board-13x13 .shudan-content {
+  background: url("./board-13x13.png") center / 100% 100% no-repeat;
+}
+
+.shudan-board-13x13 .shudan-grid {
+  display: none;
+}
+
+.shudan-board-19x19 .shudan-content {
+  background: url("./board-19x19.png") center / 100% 100% no-repeat;
+}
+
+.shudan-board-19x19 .shudan-grid {
+  display: none;
+}
+```
+
+Target `.shudan-content` so the baked grid aligns with the vertex area. The
+first and last intersections should be half a vertex apart from the image edges.
+Sizes without a matching rule keep the regular board background and vector grid.
+These simple rules assume the whole board is visible; themes that use `rangeX`
+or `rangeY` must also crop and align their background accordingly.
+
 Also override Shudan's default CSS custom properties to adjust the colors:
 
 ```css

--- a/docs/README.md
+++ b/docs/README.md
@@ -164,10 +164,12 @@ Also override Shudan's default CSS custom properties to adjust the colors:
 }
 ```
 
-Shudan adds random classes `.shudan-random_{n}` where `n = 0,...,4` to
-`.shudan-stone-image`. Say, you have white shell stone images with different
-shell patterns. You can use the random classes to randomly assign a different
-pattern to each stone:
+Shudan adds random classes `.shudan-random_{n}` to `.shudan-stone-image`. By
+default, `n = 0,...,4`. Pass `stoneVariationCounts` to configure independent
+counts for black and white stones, for example `{1: 12, [-1]: 7}`. Invalid or
+missing counts default to five. Say, you have white shell stone images with
+different shell patterns. You can use the random classes to randomly assign a
+different pattern to each stone:
 
 ```css
 .shudan-stone-image.shudan-sign_-1 {

--- a/src/Goban.d.ts
+++ b/src/Goban.d.ts
@@ -52,6 +52,7 @@ export interface GobanProps {
 
   fuzzyStonePlacement?: boolean;
   animateStonePlacement?: boolean;
+  stoneVariationCounts?: Partial<Record<1 | -1, number>>;
 
   signMap?: Map<0 | 1 | -1>;
   markerMap?: Map<Marker | null>;

--- a/src/Goban.js
+++ b/src/Goban.js
@@ -85,12 +85,15 @@ export default class Goban extends Component {
         className: classnames(
           "shudan-goban",
           "shudan-goban-image",
+          `shudan-board-${width}x${height}`,
           {
             "shudan-busy": busy,
             "shudan-coordinates": showCoordinates,
           },
           this.props.class ?? this.props.className
         ),
+        "data-shudan-board-width": width,
+        "data-shudan-board-height": height,
         style: {
           display: "inline-grid",
           gridTemplateRows: showCoordinates ? "1em 1fr 1em" : "1fr",

--- a/src/Goban.js
+++ b/src/Goban.js
@@ -16,6 +16,8 @@ import Grid from "./Grid.js";
 import Vertex from "./Vertex.js";
 import Line from "./Line.js";
 
+const defaultStoneVariationCount = 5;
+
 export default class Goban extends Component {
   constructor(props) {
     super(props);
@@ -71,7 +73,17 @@ export default class Goban extends Component {
       lines = [],
       selectedVertices = [],
       dimmedVertices = [],
+      stoneVariationCounts = {},
     } = this.props;
+
+    let getStoneVariation = (sign, seed) => {
+      let count = stoneVariationCounts?.[sign];
+      if (!Number.isSafeInteger(count) || count < 1) {
+        count = defaultStoneVariationCount;
+      }
+
+      return Math.floor(seed * count);
+    };
 
     let animatedVertices = [].concat(
       ...this.state.animatedVertices.map(neighborhood)
@@ -157,6 +169,9 @@ export default class Goban extends Component {
             xs.map((x) => {
               let equalsVertex = (v) => vertexEquals(v, [x, y]);
               let selected = selectedVertices.some(equalsVertex);
+              let sign = signMap?.[y]?.[x];
+              let ghostStone = ghostStoneMap?.[y]?.[x];
+              let variationSign = sign || ghostStone?.sign;
 
               return h(
                 Vertex,
@@ -166,12 +181,15 @@ export default class Goban extends Component {
                     position: [x, y],
 
                     shift: fuzzyStonePlacement ? shiftMap?.[y]?.[x] : 0,
-                    random: randomMap?.[y]?.[x],
-                    sign: signMap?.[y]?.[x],
+                    random: getStoneVariation(
+                      variationSign,
+                      randomMap?.[y]?.[x]
+                    ),
+                    sign,
 
                     heat: heatMap?.[y]?.[x],
                     marker: markerMap?.[y]?.[x],
-                    ghostStone: ghostStoneMap?.[y]?.[x],
+                    ghostStone,
                     dimmed: dimmedVertices.some(equalsVertex),
                     animate: animatedVertices.some(equalsVertex),
 
@@ -305,6 +323,6 @@ Goban.getDerivedStateFromProps = function (props, state) {
     ys: range(height).slice(rangeY[0], rangeY[1] + 1),
     hoshis: getHoshis(width, height),
     shiftMap: readjustShifts(signMap.map((row) => row.map((_) => random(8)))),
-    randomMap: signMap.map((row) => row.map((_) => random(4))),
+    randomMap: signMap.map((row) => row.map((_) => Math.random())),
   };
 };


### PR DESCRIPTION
This expands Shudan’s theming hooks for themes that use grid as a part of board assets instead of a generic texture and vector grid.

The Goban now exposes its rendered dimensions through a class such as shudan-board-19x19 and through separate `width` and `height` data attributes. Theme CSS can use these hooks to select a baked-grid image for the supported sizes.

Shudan also accepts independent stone variation counts for black and white. Instead of storing an integer tied to a fixed five-variation range, it stores a stable random seed per intersection and maps that seed into the active color’s range. This keeps selection uniform when the two colors have different counts and preserves stable visual assignments.

The changes are backward compatible with the existing themes.